### PR TITLE
fix mispelling in diagnostic message

### DIFF
--- a/clippy_lints/src/methods/bytes_nth.rs
+++ b/clippy_lints/src/methods/bytes_nth.rs
@@ -22,7 +22,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, recv: &'tcx E
         cx,
         BYTES_NTH,
         expr.span,
-        &format!("called `.byte().nth()` on a `{}`", caller_type),
+        &format!("called `.bytes().nth()` on a `{}`", caller_type),
         "try",
         format!(
             "{}.as_bytes().get({})",


### PR DESCRIPTION

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
fix mispelling in diagnostic message in ``[`bytes_nth`]``